### PR TITLE
feat: SCTE-35 live splicing with PTS alignment

### DIFF
--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -346,7 +346,7 @@ TS_MSC_NOWARNING(4668)  // 'xxx' is not defined as a preprocessor macro, replaci
 #include <srt/srt.h>
 
 // On Windows, access_control.h as missing in the binary installer before 1.5.3.
-#if defined(TS_WINDOWS) && SRT_VERSION_VALUE < SRT_MAKE_VERSION_VALUE(1,5,3)
+#if (defined(TS_WINDOWS) && SRT_VERSION_VALUE < SRT_MAKE_VERSION_VALUE(1,5,3)) || SRT_VERSION_VALUE < SRT_MAKE_VERSION_VALUE(1,4,2)
 #define SRT_REJX_OVERLOAD 1402 // manually defined when header is missing.
 #else
 #include <srt/access_control.h>
@@ -1046,7 +1046,9 @@ int ts::SRTSocket::Guts::listenCallback(void* param, SRTSOCKET sock, int hsversi
     Guts* guts = reinterpret_cast<Guts*>(param);
     if (guts == nullptr || (guts->listener != SRT_INVALID_SOCK && guts->sock != SRT_INVALID_SOCK)) {
         // A connection is already established, revoke all others.
+#ifndef SRT_REJX_OVERLOAD
         ::srt_setrejectreason(sock, SRT_REJX_OVERLOAD);
+#endif
         return -1;
     }
     else {
@@ -1065,7 +1067,7 @@ bool ts::SRTSocket::Guts::srtConnect(const IPv4SocketAddress& addr, Report& repo
         const int err = ::srt_getlasterror(&errno);
         std::string err_str(::srt_strerror(err, errno));
         if (err == SRT_ECONNREJ) {
-            const int reason = ::srt_getrejectreason(sock);
+            const SRT_REJECT_REASON reason = ::srt_getrejectreason(sock);
             report.debug(u"srt_connect rejected, reason: %d", {reason});
             if (reason == SRT_REJX_OVERLOAD) {
                 // Extended rejection reasons (REJX) have no meaningful error strings.

--- a/src/libtsduck/dtv/signalization/tsTablesDisplay.cpp
+++ b/src/libtsduck/dtv/signalization/tsTablesDisplay.cpp
@@ -101,8 +101,7 @@ void ts::TablesDisplay::defineArgs(Args& args)
 
 bool ts::TablesDisplay::loadArgs(DuckContext& duck, Args &args)
 {
-    _raw_dump = args.present(u"raw-dump");
-    _raw_flags = UString::HEXA;
+    setRawMode(args.present(u"raw-dump"));
     if (args.present(u"c-style")) {
         _raw_dump = true;
         _raw_flags |= UString::C_STYLE;
@@ -402,6 +401,17 @@ void ts::TablesDisplay::logLine(const UString& line)
         // Use the report object for logging.
         _duck.report().info(line);
     }
+}
+
+
+//----------------------------------------------------------------------------
+// Forces the display to set raw dump mode
+//----------------------------------------------------------------------------
+
+void ts::TablesDisplay::setRawMode(const bool enable)
+{
+    _raw_dump = enable;
+    _raw_flags = UString::HEXA;
 }
 
 

--- a/src/libtsduck/dtv/signalization/tsTablesDisplay.h
+++ b/src/libtsduck/dtv/signalization/tsTablesDisplay.h
@@ -125,6 +125,12 @@ namespace ts {
         virtual void logLine(const UString& line);
 
         //!
+        //! Force the display to enter raw mode
+        //! @param [in] enable Whether to enable raw mode.
+        //!
+        virtual void setRawMode(const bool enable);
+
+        //!
         //! Display a table on the output stream.
         //! The content of the table is interpreted according to the table id.
         //! @param [in] table The table to display.

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3275
+#define TS_COMMIT 2042

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3273
+#define TS_COMMIT 3274

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3274
+#define TS_COMMIT 3275

--- a/src/tsplugins/tsplugin_spliceinject.cpp
+++ b/src/tsplugins/tsplugin_spliceinject.cpp
@@ -118,6 +118,8 @@ namespace ts {
         int64_t       _max_file_size;
         size_t        _queue_size;
         SectionPtr    _null_splice;       // A null splice section to maintain PID bitrate.
+        
+        virtual void parseSection(std::istringstream& strm, FType type, uint64_t pts);
 
         // The plugin contains two internal threads in addition to the packet processing thread.
         // One thread polls input files and another thread receives UDP messages.
@@ -130,7 +132,7 @@ namespace ts {
         {
             TS_NOBUILD_NOCOPY(SpliceCommand);
         public:
-            SpliceCommand(SpliceInjectPlugin* plugin, const SectionPtr& sec);
+            SpliceCommand(SpliceInjectPlugin* plugin, const SectionPtr& sec, uint64_t known_pts);
 
             SpliceInformationTable sit;       // The analyzed Splice Information Table.
             SectionPtr             section;   // The binary SIT section.
@@ -764,6 +766,51 @@ bool ts::SpliceInjectPlugin::doStuffing()
 }
 
 
+void ts::SpliceInjectPlugin::parseSection(std::istringstream& strm, FType type, uint64_t pts) {
+    tsp->debug(u"parsing section:\n%s",
+               {UString::Dump(strm.str().c_str(), strm.str().length(), UString::HEXA | UString::ASCII, 4)});
+
+    // Analyze the message as a binary, XML or JSON section file.
+    SectionFile secFile(duck);
+    if (!secFile.load(strm, type)) {
+        // Error loading sections, error message already reported.
+        return;
+    }
+
+    // Loop on all sections in the file or message.
+    // Each section is expected to be a splice information section.
+    for (auto it = secFile.sections().begin(); it != secFile.sections().end(); ++it) {
+        SectionPtr sec(*it);
+        if (!sec.isNull()) {
+            if (sec->tableId() != TID_SCTE35_SIT) {
+                tsp->error(u"unexpected section, %s, ignored",
+                           {names::TID(duck, sec->tableId(), CASID_NULL, NamesFlags::VALUE)});
+            } else {
+                CommandPtr cmd(new SpliceCommand(this, sec, pts));
+                if (cmd.isNull() || !cmd->sit.isValid() || cmd->last_pts == INVALID_PTS) {
+                    tsp->error(u"received invalid splice information "
+                               u"section, ignored");
+                } else {
+                    tsp->verbose(u"enqueuing %s", {*cmd});
+                    if (!_queue.enqueue(cmd, 0)) {
+                        tsp->warning(u"queue overflow, dropped one section");
+                    }
+                }
+            }
+        }
+    }
+
+    // If --wait-first-batch was specified, signal when the first batch
+    // of commands is queued.
+    if (_wait_first_batch && !_wfb_received) {
+        GuardCondition lock(_wfb_mutex, _wfb_condition);
+        _wfb_received = true;
+        lock.signal();
+    }
+    return;
+}
+
+
 //----------------------------------------------------------------------------
 // Process a section message. Invoked from listener threads.
 //----------------------------------------------------------------------------
@@ -778,8 +825,47 @@ void ts::SpliceInjectPlugin::processSectionMessage(const uint8_t* addr, size_t s
         if (addr[0] == TID_SCTE35_SIT) {
             // First byte is the table id of a splice information table.
             type = FType::BINARY;
-        }
-        else if (addr[0] == '<') {
+        } else if (addr[0] == '*') {
+            // Start of splicemonitor
+            type = FType::BINARY;
+
+            addr += 2; // Skip initial "* "
+            size -= 2;
+
+            const uint8_t *end_line = addr + 1;
+            while (*end_line != '\n') {
+                end_line++;
+            }
+
+            uint64_t result = 0;
+            for (const uint8_t *i = addr; i < end_line; ++i) {
+                result = (result * 10) + (*i - '0');
+            }
+            size -= end_line - addr;
+            addr = end_line + 1;
+            size -= 2;
+            tsp->debug(u"loaded splicemonitor pts: %d", {result});
+
+            std::ostringstream os;
+
+            for (size_t i = 0; i < size; i += 3) {
+                unsigned int byteValue;
+                std::stringstream ss;
+                ss << std::hex << addr[i] << addr[i + 1];
+                ss >> byteValue;
+
+                if (byteValue > 0xFF) {
+                    throw std::runtime_error("Invalid byte value");
+                }
+
+                uint8_t byte = static_cast<uint8_t>(byteValue);
+                os.write(reinterpret_cast<char *>(&byte), sizeof(byte));
+            }
+
+            std::istringstream strm = std::istringstream(os.str(), std::ios::binary);
+            return parseSection(strm, FType::BINARY, result);
+
+        } else if (addr[0] == '<') {
             // Typically the start of an XML definition.
             type = FType::XML;
         }
@@ -818,44 +904,7 @@ void ts::SpliceInjectPlugin::processSectionMessage(const uint8_t* addr, size_t s
 
     // Consider the memory as a C++ input stream.
     std::istringstream strm(std::string(reinterpret_cast<const char*>(addr), size));
-    tsp->debug(u"parsing section:\n%s", {UString::Dump(addr, size, UString::HEXA | UString::ASCII, 4)});
-
-    // Analyze the message as a binary, XML or JSON section file.
-    SectionFile secFile(duck);
-    if (!secFile.load(strm, type)) {
-        // Error loading sections, error message already reported.
-        return;
-    }
-
-    // Loop on all sections in the file or message.
-    // Each section is expected to be a splice information section.
-    for (auto it = secFile.sections().begin(); it != secFile.sections().end(); ++it) {
-        SectionPtr sec(*it);
-        if (!sec.isNull()) {
-            if (sec->tableId() != TID_SCTE35_SIT) {
-                tsp->error(u"unexpected section, %s, ignored", {names::TID(duck, sec->tableId(), CASID_NULL, NamesFlags::VALUE)});
-            }
-            else {
-                CommandPtr cmd(new SpliceCommand(this, sec));
-                if (cmd.isNull() || !cmd->sit.isValid()) {
-                    tsp->error(u"received invalid splice information section, ignored");
-                }
-                else {
-                    tsp->verbose(u"enqueuing %s", {*cmd});
-                    if (!_queue.enqueue(cmd, 0)) {
-                        tsp->warning(u"queue overflow, dropped one section");
-                    }
-                }
-            }
-        }
-    }
-
-    // If --wait-first-batch was specified, signal when the first batch of commands is queued.
-    if (_wait_first_batch && !_wfb_received) {
-        GuardCondition lock(_wfb_mutex, _wfb_condition);
-        _wfb_received = true;
-        lock.signal();
-    }
+    parseSection(strm, type, _last_pts);
 }
 
 
@@ -863,7 +912,7 @@ void ts::SpliceInjectPlugin::processSectionMessage(const uint8_t* addr, size_t s
 // Splice command object constructor
 //----------------------------------------------------------------------------
 
-ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin, const SectionPtr& sec) :
+ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin *plugin, const SectionPtr &sec, const uint64_t known_pts) :
     sit(),
     section(sec),
     next_pts(INVALID_PTS),   // inject immediately
@@ -884,18 +933,20 @@ ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin,
         sit.deserialize(_plugin->duck, table);
     }
 
-    // The initial values for the member fields are set for one immediate injection.
-    // This must be changed for non-immediate splice_insert() and time_signal() commands.
+    // The initial values for the member fields are set for one immediate
+    // injection. This must be changed for non-immediate splice_insert() and
+    // time_signal() commands.
     if (sit.isValid() &&
         ((sit.splice_command_type == SPLICE_TIME_SIGNAL && sit.time_signal.set()) ||
-         (sit.splice_command_type == SPLICE_INSERT && !sit.splice_insert.canceled && !sit.splice_insert.immediate)))
-    {
+        (sit.splice_command_type == SPLICE_INSERT && !sit.splice_insert.canceled))) {
         // Compute the splice event PTS value. This will be the last time for
         // the splice command injection since the event is obsolete afterward.
         if (sit.splice_command_type == SPLICE_INSERT) {
             if (sit.splice_insert.program_splice) {
                 // Common PTS value, program-wide.
-                if (sit.splice_insert.program_pts.set()) {
+                if (sit.splice_insert.immediate) {
+                    last_pts = known_pts;
+                } else if (sit.splice_insert.program_pts.set()) {
                     last_pts = sit.splice_insert.program_pts.value();
                 }
             }
@@ -917,7 +968,9 @@ ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin,
         // Otherwise, compute initial PTS and injection count.
         if (last_pts != INVALID_PTS) {
             last_pts = (last_pts + sit.pts_adjustment) & PTS_DTS_MASK;
-            count = _plugin->_inject_count;
+            if (sit.splice_command_type != SPLICE_INSERT || !sit.splice_insert.immediate) {
+                count = _plugin->_inject_count;
+            }
             // Preceding delay for injection in PTS units.
             const uint64_t preceding = (_plugin->_start_delay * SYSTEM_CLOCK_SUBFREQ) / MilliSecPerSec;
             // Compute the first PTS time for injection.

--- a/src/tsplugins/tsplugin_splicemonitor.cpp
+++ b/src/tsplugins/tsplugin_splicemonitor.cpp
@@ -115,6 +115,7 @@ namespace ts {
         xml::JSONConverter          _x2j_conv;         // XML-to-JSON converter.
         json::RunningDocument       _json_doc;         // JSON document, built on-the-fly.
         uint64_t                    _last_pts;         // The last known PTS of all packet
+        uint64_t                    _splice_index;      // Incrementing counter of splices
 
         // Associate all audio/video PID's in a PMT to a splice PID.
         void setSplicePID(const PMT&, PID);
@@ -164,7 +165,8 @@ ts::SpliceMonitorPlugin::SpliceMonitorPlugin(TSP* tsp_) :
     _sig_demux(duck, this),
     _x2j_conv(*tsp),
     _json_doc(*tsp),
-    _last_pts(0)
+    _last_pts(0),
+    _splice_index(0)
 {
     _json_args.defineArgs(*this, true, u"Build a JSON report into the specified file. Using '-' means standard output.");
 
@@ -501,7 +503,8 @@ void ts::SpliceMonitorPlugin::processEvent(PID splice_pid, uint32_t event_id, ui
 
     if (_injector_log) {
         UString file_name = UString();
-        file_name.format(u"%s_%d.bin", {_output_file, _last_pts});
+        file_name.format(u"%s_%d.bin", {_output_file, _splice_index});
+        _splice_index += 1;
         duck.setOutput(file_name);
     }
 

--- a/src/tsplugins/tsplugin_splicemonitor.cpp
+++ b/src/tsplugins/tsplugin_splicemonitor.cpp
@@ -499,6 +499,13 @@ void ts::SpliceMonitorPlugin::processEvent(PID splice_pid, uint32_t event_id, ui
     auto evt = ctx.splice_events.find(event_id);
     bool known_event = evt != ctx.splice_events.end();
 
+    if (_injector_log) {
+        UString file_name = UString();
+        file_name.format(u"%s_%d.bin", {_output_file, _last_pts});
+        duck.setOutput(file_name);
+    }
+
+
     // Time to event in ms. Negative if event is in the past.
     Variable<MilliSecond> time_to_event;
     if (ctx.last_pts != INVALID_PTS) {
@@ -630,12 +637,6 @@ void ts::SpliceMonitorPlugin::handleTable(SectionDemux& demux, const BinaryTable
             _json_args.report(_x2j_conv.convertToJSON(doc, true)->query(u"#nodes[0]"), _json_doc, *tsp);
         }
         else {
-            if (_injector_log) {
-                UString file_name = UString();
-                file_name.format(u"%s_%d.bin", {_output_file, event_id});
-                duck.setOutput(file_name);
-            }
-
             // Human-readable display of the SCTE-35 table.
             if (_displayed_table && !_injector_log) {
                 _display << std::endl;

--- a/src/tsplugins/tsplugin_splicemonitor.cpp
+++ b/src/tsplugins/tsplugin_splicemonitor.cpp
@@ -103,6 +103,7 @@ namespace ts {
         MilliSecond _max_preroll;       // Maximum pre-roll time in milliseconds.
         json::OutputArgs _json_args;    // JSON output.
         std::bitset<256> _log_cmds;     // List of splice commands to display.
+        bool             _injector_log; // Log multiple output files with PTS and hex data
 
         // Working data:
         TablesDisplay               _display;          // Display engine for splice information tables.
@@ -113,6 +114,7 @@ namespace ts {
         SignalizationDemux          _sig_demux;        // Signalization demux to get PMT's.
         xml::JSONConverter          _x2j_conv;         // XML-to-JSON converter.
         json::RunningDocument       _json_doc;         // JSON document, built on-the-fly.
+        uint64_t                    _last_pts;         // The last known PTS of all packet
 
         // Associate all audio/video PID's in a PMT to a splice PID.
         void setSplicePID(const PMT&, PID);
@@ -153,6 +155,7 @@ ts::SpliceMonitorPlugin::SpliceMonitorPlugin(TSP* tsp_) :
     _max_preroll(0),
     _json_args(),
     _log_cmds(),
+    _injector_log(),
     _display(duck),
     _displayed_table(false),
     _splice_contexts(),
@@ -160,7 +163,8 @@ ts::SpliceMonitorPlugin::SpliceMonitorPlugin(TSP* tsp_) :
     _section_demux(duck, this),
     _sig_demux(duck, this),
     _x2j_conv(*tsp),
-    _json_doc(*tsp)
+    _json_doc(*tsp),
+    _last_pts(0)
 {
     _json_args.defineArgs(*this, true, u"Build a JSON report into the specified file. Using '-' means standard output.");
 
@@ -238,6 +242,11 @@ ts::SpliceMonitorPlugin::SpliceMonitorPlugin(TSP* tsp_) :
     help(u"time-pid",
          u"Specify one video or audio PID containing PTS time stamps to link with SCTE-35 sections to monitor. "
          u"By default, the PMT's are used to link between PTS PID's and SCTE-35 PID's.");
+
+    option(u"injector", 0);
+    help(u"injector",
+         u"Instead of monitor data, output files for spliceinjector usage."
+         u"Will force a hex dump file-name appended with event id-of each event preceded by the most recent PTS.");
 }
 
 
@@ -285,6 +294,19 @@ bool ts::SpliceMonitorPlugin::getOptions()
     getIntValue(_min_repetition, u"min-repetition");
     getIntValue(_max_repetition, u"max-repetition");
     getIntValues(_log_cmds, u"select-commands");
+    _injector_log = present(u"injector");
+    if (_injector_log) {
+        _display.setRawMode(true);
+        _log_cmds.set(SPLICE_INSERT); // Display splice insert commands
+        if (_output_file.empty()) {
+            tsp->error(u"Must specify output file for injector mode");
+            return false;
+        }
+        if (_json_args.useJSON()) {
+            tsp->error(u"Cannot use JSON mode in injector mode");
+            return false;
+        }
+    }
     if (present(u"all-commands")) {
         _log_cmds.set(); // Display all splice commands
     }
@@ -329,9 +351,10 @@ bool ts::SpliceMonitorPlugin::start()
         json::ValuePtr root;
         return _json_doc.open(root, _output_file, std::cout);
     }
-    else {
+    else if (!_injector_log) {
         return duck.setOutput(_output_file);
     }
+    return true;
 }
 
 
@@ -403,18 +426,22 @@ void ts::SpliceMonitorPlugin::setSplicePID(const PMT& pmt, PID splice_pid)
 ts::UString ts::SpliceMonitorPlugin::message(PID splice_pid, uint32_t event_id, const UChar* format, std::initializer_list<ArgMixIn> args)
 {
     UString line;
-    if (_packet_index) {
-        line.format(u"packet %'d, ", {tsp->pluginPackets()});
-    }
-    if (splice_pid != PID_NULL) {
-        SpliceContext& ctx(_splice_contexts[splice_pid]);
-        line.format(u"splice PID 0x%X (%<d), ", {splice_pid});
-        if (event_id != SpliceInsert::INVALID_EVENT_ID) {
-            const SpliceEvent& evt(ctx.splice_events[event_id]);
-            line.format(u"event 0x%X (%<d) %d, ", {evt.event_id, evt.event_out ? u"out" : u"in"});
+    if (_injector_log) {
+        line.format(u"%d", {_last_pts});
+    } else {
+        if (_packet_index) {
+            line.format(u"packet %'d, ", {tsp->pluginPackets()});
         }
+        if (splice_pid != PID_NULL) {
+            SpliceContext& ctx(_splice_contexts[splice_pid]);
+            line.format(u"splice PID 0x%X (%<d), ", {splice_pid});
+            if (event_id != SpliceInsert::INVALID_EVENT_ID) {
+                const SpliceEvent& evt(ctx.splice_events[event_id]);
+                line.format(u"event 0x%X (%<d) %d, ", {evt.event_id, evt.event_out ? u"out" : u"in"});
+            }
+        }
+        line.format(format, args);
     }
-    line.format(format, args);
     return line;
 }
 
@@ -429,7 +456,7 @@ void ts::SpliceMonitorPlugin::display(const UString& line)
         tsp->info(line);
     }
     else {
-        if (_displayed_table) {
+        if (_displayed_table && !_injector_log) {
             _displayed_table = false;
             _display << std::endl;
         }
@@ -603,8 +630,14 @@ void ts::SpliceMonitorPlugin::handleTable(SectionDemux& demux, const BinaryTable
             _json_args.report(_x2j_conv.convertToJSON(doc, true)->query(u"#nodes[0]"), _json_doc, *tsp);
         }
         else {
+            if (_injector_log) {
+                UString file_name = UString();
+                file_name.format(u"%s_%d.bin", {_output_file, event_id});
+                duck.setOutput(file_name);
+            }
+
             // Human-readable display of the SCTE-35 table.
-            if (_displayed_table) {
+            if (_displayed_table && !_injector_log) {
                 _display << std::endl;
             }
             _display.displayTable(table);
@@ -634,6 +667,7 @@ ts::ProcessorPlugin::Status ts::SpliceMonitorPlugin::processPacket(TSPacket& pkt
         SpliceContext& ctx(_splice_contexts[spid]);
         ctx.last_pts = pkt.getPTS();
         ctx.last_pts_packet = tsp->pluginPackets();
+        _last_pts = pkt.getPTS();
 
         for (auto it = ctx.splice_events.begin(); it != ctx.splice_events.end(); ) {
             SpliceEvent& evt(it->second);
@@ -665,7 +699,7 @@ ts::ProcessorPlugin::Status ts::SpliceMonitorPlugin::processPacket(TSPacket& pkt
                     obj.add(u"pre-roll-ms", preroll);
                     _json_args.report(obj, _json_doc, *tsp);
                 }
-                else {
+                else if (!_injector_log) {
                     display(line);
                 }
 


### PR DESCRIPTION
#### Affected components:
`spliceinject` and `splicemonitor`

#### Brief description of the proposed changes:
1. Splicemonitor new parameter `--log-pts` that forces a "* {last known PTS}" instead to file before splice dump
2. Splicemonitor exposes display args in order to enable "-r" for raw dump hex output
3. Splicemonitor writes each table to individual files
4. Spliceinject reads `*` as the first field from a file to enable splicemonitor output
5. Spliceinject parses PTS and table dump from splicemonitor output files as SCTE splices
6. Spliceinject uses the PTS to align `immediate` splice inserts with correct video section